### PR TITLE
Fix division by zero with minimum top in scaling. This allow zero input value.

### DIFF
--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -790,6 +790,8 @@ def scale_bar_values( bar, top, maxrow ):
     """
     Return a list of bar values aliased to integer values of maxrow.
     """
+    if top < 1:
+        top = 1
     return [maxrow - int(float(v) * maxrow / top + 0.5) for v in bar]
 
 


### PR DESCRIPTION
When the result of command is "zero", it throws an division by zero exception.
This is due to calculation made in `scale_bar_values` with the top value. To ensure we can start the graph with a value _zero_, I added a minimum top of `1` . This fix also the issue when your graph end by zero values.
